### PR TITLE
feat: lock down to only Cloudflare ingress

### DIFF
--- a/terraform/cloud_armor.tf
+++ b/terraform/cloud_armor.tf
@@ -1,0 +1,63 @@
+# Cloud Armor security policy — allows only Cloudflare IP ranges.
+#
+# Note: Cloudflare occasionally adds new IP ranges. Re-running `terraform apply`
+# will keep the policy current. Consider a scheduled CI run or drift detection
+# to automate this.
+
+data "cloudflare_ip_ranges" "cloudflare" {}
+
+locals {
+  # Cloud Armor allows a maximum of 10 IP ranges per rule, so the ranges are
+  # split into chunks and each chunk gets its own rule.
+  cf_ipv4_chunks = chunklist(data.cloudflare_ip_ranges.cloudflare.ipv4_cidr_blocks, 10)
+  cf_ipv6_chunks = chunklist(data.cloudflare_ip_ranges.cloudflare.ipv6_cidr_blocks, 10)
+}
+
+resource "google_compute_security_policy" "cloudflare_only" {
+  name = "${var.repository_name}-cloudflare-only"
+
+  # Allow Cloudflare IPv4 ranges.
+  dynamic "rule" {
+    for_each = local.cf_ipv4_chunks
+    content {
+      action   = "allow"
+      priority = 1000 + rule.key
+      match {
+        versioned_expr = "SRC_IPS_V1"
+        config {
+          src_ip_ranges = rule.value
+        }
+      }
+      description = "Allow Cloudflare IPv4 chunk ${rule.key}"
+    }
+  }
+
+  # Allow Cloudflare IPv6 ranges.
+  dynamic "rule" {
+    for_each = local.cf_ipv6_chunks
+    content {
+      action   = "allow"
+      priority = 2000 + rule.key
+      match {
+        versioned_expr = "SRC_IPS_V1"
+        config {
+          src_ip_ranges = rule.value
+        }
+      }
+      description = "Allow Cloudflare IPv6 chunk ${rule.key}"
+    }
+  }
+
+  # Default: deny everything that is not Cloudflare.
+  rule {
+    action   = "deny(403)"
+    priority = 2147483647
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "Default: deny all non-Cloudflare traffic"
+  }
+}

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -6,6 +6,26 @@ data "cloudflare_zone" "main" {
   name = "simonandrews.ca"
 }
 
+# ── Zone security settings ────────────────────────────────────────────────────
+# Full (Strict) SSL verifies the Google-managed cert on the load balancer.
+# HSTS tells browsers to always use HTTPS for this domain.
+
+resource "cloudflare_zone_settings_override" "main" {
+  zone_id = data.cloudflare_zone.main.id
+
+  settings {
+    ssl             = "strict"
+    min_tls_version = "1.2"
+
+    security_header {
+      enabled            = true
+      include_subdomains = true
+      max_age            = 31536000
+      preload            = true
+    }
+  }
+}
+
 # ── Certificate Manager DNS authorisation records ─────────────────────────────
 # These CNAMEs allow Google to validate domain ownership without needing to
 # disable Cloudflare proxying.

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -6,26 +6,6 @@ data "cloudflare_zone" "main" {
   name = "simonandrews.ca"
 }
 
-# ── Zone security settings ────────────────────────────────────────────────────
-# Full (Strict) SSL verifies the Google-managed cert on the load balancer.
-# HSTS tells browsers to always use HTTPS for this domain.
-
-resource "cloudflare_zone_settings_override" "main" {
-  zone_id = data.cloudflare_zone.main.id
-
-  settings {
-    ssl             = "strict"
-    min_tls_version = "1.2"
-
-    security_header {
-      enabled            = true
-      include_subdomains = true
-      max_age            = 31536000
-      preload            = true
-    }
-  }
-}
-
 # ── Certificate Manager DNS authorisation records ─────────────────────────────
 # These CNAMEs allow Google to validate domain ownership without needing to
 # disable Cloudflare proxying.

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -71,8 +71,7 @@ resource "google_compute_backend_service" "main" {
     group = google_compute_region_network_endpoint_group.cloud_run.id
   }
 
-  # Cloud Armor policy is attached here in Stage 3.
-  # security_policy = google_compute_security_policy.cloudflare_only.id
+  security_policy = google_compute_security_policy.cloudflare_only.id
 }
 
 # ── HTTPS URL map + proxy + forwarding rule ───────────────────────────────────


### PR DESCRIPTION
Limits the load balancer to only accept incoming requests from
Cloudflare IP addresses
