### PR TITLE
fix: serve public dir in Storybook and replace missing logo

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,6 +10,7 @@ const config: StorybookConfig = {
     name: "@storybook/nextjs",
     options: {},
   },
+  staticDirs: ["../public"],
 };
 
 export default config;

--- a/components/Associations/Associations.stories.tsx
+++ b/components/Associations/Associations.stories.tsx
@@ -67,8 +67,8 @@ export const SingleWithRasterLogo = ({
     logo={{
       type: "img",
       imgAttributes: {
-        alt: "Logo for A Space Company",
-        src: "/images/gatsby-astronaut.png",
+        alt: "Olympia Trust Company logo",
+        src: "/images/logo-olympia-trust-company.png",
       },
     }}
   />


### PR DESCRIPTION
Adds staticDirs: ['../public'] to .storybook/main.ts so /images/...
URL references in stories resolve correctly. Replaces the Gatsby
placeholder gatsby-astronaut.png (never present in this repo) with
logo-olympia-trust-company.png in the Associations story.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
