### PR TITLE
feat: migrate simon360.com DNS records to Cloudflare

### DIFF
--- a/scripts/check-simon360-dns.sh
+++ b/scripts/check-simon360-dns.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Polls until simon360.com nameservers switch to Cloudflare, then prints all
+# key DNS records to confirm the migration is correct.
+# Run this after updating the nameservers at Hover.
+set -euo pipefail
+
+echo "Polling for simon360.com Cloudflare nameserver switchover (every 30s)..."
+echo ""
+
+while true; do
+  NS=$(dig simon360.com NS +short | sort)
+  if echo "$NS" | grep -qi "cloudflare.com"; then
+    echo "✓ Cloudflare nameservers are live:"
+    echo "$NS" | sed 's/^/  /'
+    echo ""
+    echo "A (@):"
+    dig simon360.com A +short | sed 's/^/  /'
+    echo "CNAME (www):"
+    dig www.simon360.com CNAME +short | sed 's/^/  /'
+    echo "MX (@):"
+    dig simon360.com MX +short | sed 's/^/  /'
+    echo "TXT (@):"
+    dig simon360.com TXT +short | sed 's/^/  /'
+    echo "TXT (_dmarc):"
+    dig _dmarc.simon360.com TXT +short | sed 's/^/  /'
+    echo "TXT (_atproto):"
+    dig _atproto.simon360.com TXT +short | sed 's/^/  /'
+    echo "CNAME (fm1._domainkey):"
+    dig fm1._domainkey.simon360.com CNAME +short | sed 's/^/  /'
+    break
+  else
+    echo "$(date +%T) — Still on Hover NS: $(echo "$NS" | tr '\n' ' ')"
+  fi
+  sleep 30
+done

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -1,9 +1,13 @@
-# ── Zone ──────────────────────────────────────────────────────────────────────
-# Create the zone manually in the Cloudflare dashboard, then Terraform will
-# manage all DNS records within it.
+# ── Zones ─────────────────────────────────────────────────────────────────────
+# Create zones manually in the Cloudflare dashboard, then Terraform will
+# manage all DNS records within them.
 
 data "cloudflare_zone" "main" {
   name = "simonandrews.ca"
+}
+
+data "cloudflare_zone" "simon360" {
+  name = "simon360.com"
 }
 
 # ── Certificate Manager DNS authorisation records ─────────────────────────────
@@ -152,5 +156,100 @@ resource "cloudflare_record" "dkim_fm3" {
   type    = "CNAME"
   content = "fm3.simonandrews.ca.dkim.fmhosted.com"
   proxied = false
+  ttl     = 900
+}
+
+# ── simon360.com ──────────────────────────────────────────────────────────────
+# Phase 1: DNS records migrated exactly from Hover. Web records are DNS-only
+# (proxied = false) while they still point to Vercel.
+
+resource "cloudflare_record" "simon360_apex_a" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "@"
+  type    = "A"
+  content = "76.76.21.21"
+  proxied = false
+  ttl     = 300
+}
+
+resource "cloudflare_record" "simon360_www" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "www"
+  type    = "CNAME"
+  content = "cname.vercel-dns.com"
+  proxied = false
+  ttl     = 300
+}
+
+# ── simon360.com email records ────────────────────────────────────────────────
+
+resource "cloudflare_record" "simon360_mx_1" {
+  zone_id  = data.cloudflare_zone.simon360.id
+  name     = "@"
+  type     = "MX"
+  content  = "in1-smtp.messagingengine.com"
+  priority = 10
+  ttl      = 900
+}
+
+resource "cloudflare_record" "simon360_mx_2" {
+  zone_id  = data.cloudflare_zone.simon360.id
+  name     = "@"
+  type     = "MX"
+  content  = "in2-smtp.messagingengine.com"
+  priority = 20
+  ttl      = 900
+}
+
+resource "cloudflare_record" "simon360_spf" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "@"
+  type    = "TXT"
+  content = "v=spf1 include:spf.messagingengine.com -all"
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simon360_dmarc" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "_dmarc"
+  type    = "TXT"
+  content = "v=DMARC1; p=none; pct=100; rua=mailto:re+uarxffta0cn@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simon360_dkim_fm1" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "fm1._domainkey"
+  type    = "CNAME"
+  content = "fm1.simon360.com.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simon360_dkim_fm2" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "fm2._domainkey"
+  type    = "CNAME"
+  content = "fm2.simon360.com.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simon360_dkim_fm3" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "fm3._domainkey"
+  type    = "CNAME"
+  content = "fm3.simon360.com.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+# ── simon360.com other records ────────────────────────────────────────────────
+
+resource "cloudflare_record" "simon360_atproto" {
+  zone_id = data.cloudflare_zone.simon360.id
+  name    = "_atproto"
+  type    = "TXT"
+  content = "did=did:plc:d7kipkqscf4cnprdnb6ckksf"
   ttl     = 900
 }


### PR DESCRIPTION
## Summary

- Adds `data.cloudflare_zone.simon360` data source for the `simon360.com` zone (zone must be created manually in Cloudflare dashboard first)
- Replicates all current DNS records exactly as they are on Hover: apex A, www CNAME, MX x2, SPF, DMARC, DKIM x3, AT Protocol
- Web records (`@` and `www`) are `proxied = false` since they still point to Vercel — this will change in Phase 3
- Adds `scripts/check-simon360-dns.sh` to poll until Cloudflare nameservers are authoritative

## Pre-requisite (manual, before merging)

1. Create the `simon360.com` zone in the Cloudflare dashboard
2. Update the nameservers at Hover to the Cloudflare ones

## Test plan

- [ ] Merge and confirm Terraform plan shows only additions (no changes to existing resources)
- [ ] Run `bash scripts/check-simon360-dns.sh` — exits with all records confirmed once Cloudflare NS propagates
- [ ] Verify `dig simon360.com A +short` → `76.76.21.21`
- [ ] Verify `dig simon360.com MX +short` → FastMail servers
- [ ] Confirm site still loads at simon360.com (served via Vercel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)