### PR TITLE
feat: migrate simonster.net DNS records to Cloudflare

### DIFF
--- a/scripts/check-simonster-cert.sh
+++ b/scripts/check-simonster-cert.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Polls until the simonster.net GCP Certificate Manager cert reaches ACTIVE state.
+# Run this after Terraform applies the certificate resources.
+set -euo pipefail
+
+CERT_NAME="${REPOSITORY_NAME:-simonandrews-ca}-simonster-cert"
+PROJECT="${PROJECT_ID:-simonandrews-ca-terraform}"
+
+echo "Polling certificate '$CERT_NAME' in project '$PROJECT' (every 30s)..."
+echo ""
+
+while true; do
+  STATE=$(gcloud certificate-manager certificates describe "$CERT_NAME" \
+    --project="$PROJECT" \
+    --format="value(managed.state)" 2>/dev/null || echo "NOT_FOUND")
+
+  if [ "$STATE" = "ACTIVE" ]; then
+    echo "✓ Certificate is ACTIVE — DNS validation succeeded"
+    break
+  else
+    echo "$(date +%T) — Certificate state: $STATE"
+  fi
+  sleep 30
+done

--- a/scripts/check-simonster-dns.sh
+++ b/scripts/check-simonster-dns.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Polls until simonster.net nameservers switch to Cloudflare, then prints all
+# key DNS records to confirm the migration is correct.
+# Run this after updating the nameservers at Hover.
+set -euo pipefail
+
+echo "Polling for simonster.net Cloudflare nameserver switchover (every 30s)..."
+echo ""
+
+while true; do
+  NS=$(dig simonster.net NS +short | sort)
+  if echo "$NS" | grep -qi "cloudflare.com"; then
+    echo "✓ Cloudflare nameservers are live:"
+    echo "$NS" | sed 's/^/  /'
+    echo ""
+    echo "A (@):"
+    dig simonster.net A +short | sed 's/^/  /'
+    echo "CNAME (www):"
+    dig www.simonster.net CNAME +short | sed 's/^/  /'
+    echo "MX (@):"
+    dig simonster.net MX +short | sed 's/^/  /'
+    echo "TXT (@):"
+    dig simonster.net TXT +short | sed 's/^/  /'
+    echo "TXT (_dmarc):"
+    dig _dmarc.simonster.net TXT +short | sed 's/^/  /'
+    echo "CNAME (fm1._domainkey):"
+    dig fm1._domainkey.simonster.net CNAME +short | sed 's/^/  /'
+    break
+  else
+    echo "$(date +%T) — Still on Hover NS: $(echo "$NS" | tr '\n' ' ')"
+  fi
+  sleep 30
+done

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -10,6 +10,10 @@ data "cloudflare_zone" "simon360" {
   name = "simon360.com"
 }
 
+data "cloudflare_zone" "simonster" {
+  name = "simonster.net"
+}
+
 # ── Certificate Manager DNS authorisation records ─────────────────────────────
 # These CNAMEs allow Google to validate domain ownership without needing to
 # disable Cloudflare proxying.
@@ -261,5 +265,91 @@ resource "cloudflare_record" "simon360_atproto" {
   name    = "_atproto"
   type    = "TXT"
   content = "did=did:plc:d7kipkqscf4cnprdnb6ckksf"
+  ttl     = 900
+}
+
+# ── simonster.net ─────────────────────────────────────────────────────────────
+
+# Phase 1: DNS records migrated exactly from Hover. Web records are DNS-only
+# (proxied = false) while they still point to Vercel.
+
+resource "cloudflare_record" "simonster_apex_a" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = "@"
+  type    = "A"
+  content = "76.76.21.21"
+  proxied = false
+  ttl     = 300
+}
+
+resource "cloudflare_record" "simonster_www" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = "www"
+  type    = "CNAME"
+  content = "cname.vercel-dns.com"
+  proxied = false
+  ttl     = 300
+}
+
+# ── simonster.net email records ───────────────────────────────────────────────
+
+resource "cloudflare_record" "simonster_mx_1" {
+  zone_id  = data.cloudflare_zone.simonster.id
+  name     = "@"
+  type     = "MX"
+  content  = "in1-smtp.messagingengine.com"
+  priority = 10
+  ttl      = 900
+}
+
+resource "cloudflare_record" "simonster_mx_2" {
+  zone_id  = data.cloudflare_zone.simonster.id
+  name     = "@"
+  type     = "MX"
+  content  = "in2-smtp.messagingengine.com"
+  priority = 20
+  ttl      = 900
+}
+
+resource "cloudflare_record" "simonster_spf" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = "@"
+  type    = "TXT"
+  content = "v=spf1 include:spf.messagingengine.com -all"
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simonster_dmarc" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = "_dmarc"
+  type    = "TXT"
+  content = "v=DMARC1; p=none; pct=100; rua=mailto:re+zrmvwfsciej@dmarc.postmarkapp.com; sp=none; aspf=r;"
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simonster_dkim_fm1" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = "fm1._domainkey"
+  type    = "CNAME"
+  content = "fm1.simonster.net.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simonster_dkim_fm2" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = "fm2._domainkey"
+  type    = "CNAME"
+  content = "fm2.simonster.net.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+resource "cloudflare_record" "simonster_dkim_fm3" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = "fm3._domainkey"
+  type    = "CNAME"
+  content = "fm3.simonster.net.dkim.fmhosted.com"
+  proxied = false
   ttl     = 900
 }

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -82,6 +82,7 @@ resource "google_certificate_manager_certificate_map_entry" "simon360_wildcard" 
   hostname     = "*.simon360.com"
 }
 
+
 # ── Serverless NEG (Cloud Run backend) ────────────────────────────────────────
 
 resource "google_compute_region_network_endpoint_group" "cloud_run" {
@@ -124,6 +125,7 @@ resource "google_compute_url_map" "main" {
     path_matcher = "simon360-redirect"
   }
 
+
   path_matcher {
     name            = "storybook-paths"
     default_service = google_compute_backend_service.storybook.id
@@ -138,6 +140,7 @@ resource "google_compute_url_map" "main" {
       strip_query            = false
     }
   }
+
 }
 
 resource "google_compute_target_https_proxy" "main" {


### PR DESCRIPTION
## Summary

- Adds `data.cloudflare_zone.simonster` data source for the `simonster.net` zone (zone must be created manually in Cloudflare dashboard first)
- Replicates all current DNS records exactly as they are on Hover: apex A, www CNAME, MX x2, SPF, DMARC, DKIM x3
- Web records (`@` and `www`) are `proxied = false` since they still point to Vercel — this will change in Phase 3
- The duplicate `www` CNAME (15-min TTL) is dropped; only the 5-min one is kept
- Adds `scripts/check-simonster-dns.sh` and `scripts/check-simonster-cert.sh` for later verification steps

## Pre-requisite (manual, before merging)

1. Create the `simonster.net` zone in the Cloudflare dashboard
2. Update the nameservers at Hover to the Cloudflare ones

## Test plan

- [ ] Merge and confirm Terraform plan shows only additions
- [ ] Run `bash scripts/check-simonster-dns.sh` — exits once Cloudflare NS propagates
- [ ] Verify `dig simonster.net A +short` → `76.76.21.21`
- [ ] Verify `dig simonster.net MX +short` → FastMail servers
- [ ] Confirm site still loads at simonster.net (served via Vercel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)