### PR TITLE
feat: provision SSL certificate for simonster.net

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -270,6 +270,15 @@ resource "cloudflare_record" "simon360_atproto" {
 
 # ── simonster.net ─────────────────────────────────────────────────────────────
 
+resource "cloudflare_record" "simonster_cert_auth" {
+  zone_id = data.cloudflare_zone.simonster.id
+  name    = google_certificate_manager_dns_authorization.simonster.dns_resource_record[0].name
+  type    = google_certificate_manager_dns_authorization.simonster.dns_resource_record[0].type
+  content = google_certificate_manager_dns_authorization.simonster.dns_resource_record[0].data
+  proxied = false
+  ttl     = 900
+}
+
 # Phase 1: DNS records migrated exactly from Hover. Web records are DNS-only
 # (proxied = false) while they still point to Vercel.
 

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -82,6 +82,40 @@ resource "google_certificate_manager_certificate_map_entry" "simon360_wildcard" 
   hostname     = "*.simon360.com"
 }
 
+# ── simonster.net certificate (DNS-authorised) ────────────────────────────────
+
+resource "google_certificate_manager_dns_authorization" "simonster" {
+  name   = "${var.repository_name}-simonster-auth"
+  domain = "simonster.net"
+
+  depends_on = [google_project_service.certificatemanager]
+}
+
+resource "google_certificate_manager_certificate" "simonster" {
+  name = "${var.repository_name}-simonster-cert"
+
+  managed {
+    domains            = ["simonster.net", "*.simonster.net"]
+    dns_authorizations = [google_certificate_manager_dns_authorization.simonster.id]
+  }
+
+  depends_on = [google_project_service.certificatemanager]
+}
+
+resource "google_certificate_manager_certificate_map_entry" "simonster_apex" {
+  name         = "${var.repository_name}-simonster-apex"
+  map          = google_certificate_manager_certificate_map.main.name
+  certificates = [google_certificate_manager_certificate.simonster.id]
+  hostname     = "simonster.net"
+}
+
+resource "google_certificate_manager_certificate_map_entry" "simonster_wildcard" {
+  name         = "${var.repository_name}-simonster-wildcard"
+  map          = google_certificate_manager_certificate_map.main.name
+  certificates = [google_certificate_manager_certificate.simonster.id]
+  hostname     = "*.simonster.net"
+}
+
 
 # ── Serverless NEG (Cloud Run backend) ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `google_certificate_manager_dns_authorization.simonster` for DNS-based ownership validation of `simonster.net`
- Adds `google_certificate_manager_certificate.simonster` covering `simonster.net` and `*.simonster.net`
- Adds cert map entries for both apex and wildcard, wired into the existing cert map
- Adds `cloudflare_record.simonster_cert_auth` — the CNAME Google needs to validate the domain

## Test plan

- [ ] Merge and confirm Terraform applies cleanly
- [ ] Run `bash scripts/check-simonster-cert.sh` — exits when cert reaches ACTIVE state
- [ ] Confirm cert is visible in GCP Console → Certificate Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)