### PR TITLE
feat: redirect simonster.net to simonandrews.ca via load balancer

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -279,25 +279,25 @@ resource "cloudflare_record" "simonster_cert_auth" {
   ttl     = 900
 }
 
-# Phase 1: DNS records migrated exactly from Hover. Web records are DNS-only
-# (proxied = false) while they still point to Vercel.
+# Web records point to the GCP load balancer, which redirects all traffic to
+# simonandrews.ca.
 
 resource "cloudflare_record" "simonster_apex_a" {
   zone_id = data.cloudflare_zone.simonster.id
   name    = "@"
   type    = "A"
-  content = "76.76.21.21"
-  proxied = false
-  ttl     = 300
+  content = google_compute_global_address.main.address
+  proxied = true
+  ttl     = 1
 }
 
 resource "cloudflare_record" "simonster_www" {
   zone_id = data.cloudflare_zone.simonster.id
   name    = "www"
   type    = "CNAME"
-  content = "cname.vercel-dns.com"
-  proxied = false
-  ttl     = 300
+  content = "simonster.net"
+  proxied = true
+  ttl     = 1
 }
 
 # ── simonster.net email records ───────────────────────────────────────────────

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -175,6 +175,21 @@ resource "google_compute_url_map" "main" {
     }
   }
 
+  host_rule {
+    hosts        = ["simonster.net", "www.simonster.net"]
+    path_matcher = "simonster-redirect"
+  }
+
+  path_matcher {
+    name = "simonster-redirect"
+
+    default_url_redirect {
+      host_redirect          = "simonandrews.ca"
+      redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+      strip_query            = false
+    }
+  }
+
 }
 
 resource "google_compute_target_https_proxy" "main" {


### PR DESCRIPTION
## Summary

- Adds `host_rule` and `path_matcher` to the URL map to permanently redirect `simonster.net` and `www.simonster.net` to `simonandrews.ca` (path-preserving 301)
- Updates `cloudflare_record.simonster_apex_a` to point at the GCP load balancer IP, with Cloudflare proxying enabled
- Updates `cloudflare_record.simonster_www` to CNAME to `simonster.net`, with Cloudflare proxying enabled

## Test plan

- [ ] Merge and confirm Terraform applies cleanly
- [ ] `curl -sI https://simonster.net` → `301` with `Location: https://simonandrews.ca`
- [ ] `curl -sI https://www.simonster.net` → `301` with `Location: https://simonandrews.ca`
- [ ] `curl -sI http://simonster.net` → `301` HTTPS redirect → `301` to simonandrews.ca
- [ ] Email records unaffected — verify MX/DKIM/DMARC still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)