### PR TITLE
feat: set up sadl.io in Cloudflare with redirect to simonandrews.ca

### DIFF
--- a/scripts/check-sadlio-cert.sh
+++ b/scripts/check-sadlio-cert.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Polls until the sadl.io GCP Certificate Manager cert reaches ACTIVE state.
+# Run this after Terraform applies.
+set -euo pipefail
+
+CERT_NAME="${REPOSITORY_NAME:-simonandrews-ca}-sadlio-cert"
+PROJECT="${PROJECT_ID:-simonandrews-ca-terraform}"
+
+echo "Polling certificate '$CERT_NAME' in project '$PROJECT' (every 30s)..."
+echo ""
+
+while true; do
+  STATE=$(gcloud certificate-manager certificates describe "$CERT_NAME" \
+    --project="$PROJECT" \
+    --format="value(managed.state)" 2>/dev/null || echo "NOT_FOUND")
+
+  if [ "$STATE" = "ACTIVE" ]; then
+    echo "✓ Certificate is ACTIVE — DNS validation succeeded"
+    break
+  else
+    echo "$(date +%T) — Certificate state: $STATE"
+  fi
+  sleep 30
+done

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -14,6 +14,10 @@ data "cloudflare_zone" "simonster" {
   name = "simonster.net"
 }
 
+data "cloudflare_zone" "sadlio" {
+  name = "sadl.io"
+}
+
 # ── Certificate Manager DNS authorisation records ─────────────────────────────
 # These CNAMEs allow Google to validate domain ownership without needing to
 # disable Cloudflare proxying.
@@ -359,6 +363,99 @@ resource "cloudflare_record" "simonster_dkim_fm3" {
   name    = "fm3._domainkey"
   type    = "CNAME"
   content = "fm3.simonster.net.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+# ── sadl.io ───────────────────────────────────────────────────────────────────
+# New domain — all records point straight to the GCP load balancer from day one.
+
+resource "cloudflare_record" "sadlio_cert_auth" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = google_certificate_manager_dns_authorization.sadlio.dns_resource_record[0].name
+  type    = google_certificate_manager_dns_authorization.sadlio.dns_resource_record[0].type
+  content = google_certificate_manager_dns_authorization.sadlio.dns_resource_record[0].data
+  proxied = false
+  ttl     = 900
+}
+
+resource "cloudflare_record" "sadlio_apex_a" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = "@"
+  type    = "A"
+  content = google_compute_global_address.main.address
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_record" "sadlio_www" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = "www"
+  type    = "CNAME"
+  content = "sadl.io"
+  proxied = true
+  ttl     = 1
+}
+
+# ── sadl.io email records ─────────────────────────────────────────────────────
+
+resource "cloudflare_record" "sadlio_mx_1" {
+  zone_id  = data.cloudflare_zone.sadlio.id
+  name     = "@"
+  type     = "MX"
+  content  = "in1-smtp.messagingengine.com"
+  priority = 10
+  ttl      = 900
+}
+
+resource "cloudflare_record" "sadlio_mx_2" {
+  zone_id  = data.cloudflare_zone.sadlio.id
+  name     = "@"
+  type     = "MX"
+  content  = "in2-smtp.messagingengine.com"
+  priority = 20
+  ttl      = 900
+}
+
+resource "cloudflare_record" "sadlio_spf" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = "@"
+  type    = "TXT"
+  content = "v=spf1 include:spf.messagingengine.com -all"
+  ttl     = 900
+}
+
+resource "cloudflare_record" "sadlio_dmarc" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = "_dmarc"
+  type    = "TXT"
+  content = "v=DMARC1; p=none; pct=100; sp=none; aspf=r;"
+  ttl     = 900
+}
+
+resource "cloudflare_record" "sadlio_dkim_fm1" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = "fm1._domainkey"
+  type    = "CNAME"
+  content = "fm1.sadl.io.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+resource "cloudflare_record" "sadlio_dkim_fm2" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = "fm2._domainkey"
+  type    = "CNAME"
+  content = "fm2.sadl.io.dkim.fmhosted.com"
+  proxied = false
+  ttl     = 900
+}
+
+resource "cloudflare_record" "sadlio_dkim_fm3" {
+  zone_id = data.cloudflare_zone.sadlio.id
+  name    = "fm3._domainkey"
+  type    = "CNAME"
+  content = "fm3.sadl.io.dkim.fmhosted.com"
   proxied = false
   ttl     = 900
 }

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -116,6 +116,40 @@ resource "google_certificate_manager_certificate_map_entry" "simonster_wildcard"
   hostname     = "*.simonster.net"
 }
 
+# ── sadl.io certificate (DNS-authorised) ──────────────────────────────────────
+
+resource "google_certificate_manager_dns_authorization" "sadlio" {
+  name   = "${var.repository_name}-sadlio-auth"
+  domain = "sadl.io"
+
+  depends_on = [google_project_service.certificatemanager]
+}
+
+resource "google_certificate_manager_certificate" "sadlio" {
+  name = "${var.repository_name}-sadlio-cert"
+
+  managed {
+    domains            = ["sadl.io", "*.sadl.io"]
+    dns_authorizations = [google_certificate_manager_dns_authorization.sadlio.id]
+  }
+
+  depends_on = [google_project_service.certificatemanager]
+}
+
+resource "google_certificate_manager_certificate_map_entry" "sadlio_apex" {
+  name         = "${var.repository_name}-sadlio-apex"
+  map          = google_certificate_manager_certificate_map.main.name
+  certificates = [google_certificate_manager_certificate.sadlio.id]
+  hostname     = "sadl.io"
+}
+
+resource "google_certificate_manager_certificate_map_entry" "sadlio_wildcard" {
+  name         = "${var.repository_name}-sadlio-wildcard"
+  map          = google_certificate_manager_certificate_map.main.name
+  certificates = [google_certificate_manager_certificate.sadlio.id]
+  hostname     = "*.sadl.io"
+}
+
 
 # ── Serverless NEG (Cloud Run backend) ────────────────────────────────────────
 
@@ -182,6 +216,21 @@ resource "google_compute_url_map" "main" {
 
   path_matcher {
     name = "simonster-redirect"
+
+    default_url_redirect {
+      host_redirect          = "simonandrews.ca"
+      redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+      strip_query            = false
+    }
+  }
+
+  host_rule {
+    hosts        = ["sadl.io", "www.sadl.io"]
+    path_matcher = "sadlio-redirect"
+  }
+
+  path_matcher {
+    name = "sadlio-redirect"
 
     default_url_redirect {
       host_redirect          = "simonandrews.ca"


### PR DESCRIPTION
## Summary

New domain — no Vercel cutover needed, so everything lands in one PR:

- Adds `data.cloudflare_zone.sadlio` for `sadl.io`
- Web records (`@` A and `www` CNAME) point straight to the GCP load balancer with Cloudflare proxying enabled
- FastMail email records: MX x2, SPF, DKIM x3, DMARC (no `rua`)
- DNS-authorised Certificate Manager cert covering `sadl.io` and `*.sadl.io`, wired into the existing cert map
- URL map rules to permanently redirect `sadl.io` and `www.sadl.io` to `simonandrews.ca` (301, path-preserving)

## Pre-requisite (manual, before merging)

1. Create the `sadl.io` zone in the Cloudflare dashboard
2. Update the nameservers at the registrar to the Cloudflare ones

## Test plan

- [ ] Merge and confirm Terraform applies cleanly
- [ ] Run `bash scripts/check-sadlio-cert.sh` — exits when cert is ACTIVE
- [ ] `curl -sI https://sadl.io` → `301` with `Location: https://simonandrews.ca`
- [ ] `curl -sI https://www.sadl.io` → `301` with `Location: https://simonandrews.ca`
- [ ] `curl -sI http://sadl.io` → `301` HTTPS redirect → `301` to simonandrews.ca
- [ ] `dig sadl.io MX +short` → FastMail servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)